### PR TITLE
add basic test (see #27)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,12 @@
     "less plugins",
     "cleancss",
     "less compression"
-  ]
+  ],
+  "devDependencies": {
+    "less": "^2.7.3",
+    "mocha": "^3.5.3"
+  },
+  "scripts": {
+    "test": "mocha"
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,17 @@
+var assert = require('assert');
+
+describe('LessPluginCleanCSS', function () {
+  it('should work as less plugin', function () {
+    var less = require('less');
+    var LessPluginCleanCSS = require('..');
+
+    var cleanCSSPlugin = new LessPluginCleanCSS({ advanced: true });
+
+    var lessString = 'body { color: #f00; }';
+
+    return less.render(lessString, { plugins: [cleanCSSPlugin] })
+      .then(function (result) {
+        assert(result.css === 'body{color:red}');
+      });
+  });
+});


### PR DESCRIPTION
This (very) basic test is based on the README example.

Also tested on node 0.12.
This should be the oldest version supported by less 2.x which this plugin is based on if I understood correctly.