### PR TITLE
Update Clean CSS to 5.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "clean-css": "^4.2.1"
+    "clean-css": "^5.1.2"
   },
   "keywords": [
     "less plugins",


### PR DESCRIPTION
Hi Core Less Team, 

My name is Austin Gardner. I work for eBay on the eBay UI team. We have a few open source component libraries (CSS + JS) that are used across eBay's website. 

We use this plugin in our CSS flow - we were wondering if we could bump the version of Clean CSS. The older version caused a small bug with some of our code. 

Let me know if you have any questions. Thanks so much for your help!