### PR TITLE
Upgrade clean css and some improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# @see http://editorconfig.org/
+
+# the buck stops here
+root = true
+
+# all files
+[*]
+end_of_line = LF
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -24,15 +24,17 @@ and then on the command line,
 lessc file.less --clean-css="--s1 --advanced --compatibility=ie8"
 ```
 
-See [clean-css](https://github.com/jakubpawlowicz/clean-css/tree/v3.0.1#how-to-use-clean-css-programmatically) for the available command options - the only differences are `advanced` and `rebase` which we default to false, because it is not always entirely safe.
+See [clean-css](https://github.com/jakubpawlowicz/clean-css/tree/v3.0.1#how-to-use-clean-css-programmatically) for the
+available command options - the only differences are `advanced` and `rebase` which we default to false, because it is
+not always entirely safe.
 
 ## Programmatic usage
 
 ```js
 var LessPluginCleanCSS = require('less-plugin-clean-css'),
     cleanCSSPlugin = new LessPluginCleanCSS({advanced: true});
-less.render(lessString, { plugins: [cleanCSSPlugin] })
-  .then(
+less.render(lessString, {plugins: [cleanCSSPlugin]})
+    .then(
 ```
 
 ## Browser usage

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Compresses the css output from less using [clean-css](https://github.com/jakubpa
 
 ## lessc usage
 
-```
+```bash
 npm install -g less-plugin-clean-css
 ```
 
 and then on the command line,
 
-```
+```bash
 lessc file.less --clean-css="--s1 --advanced --compatibility=ie8"
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Compresses the css output from less using [clean-css](https://github.com/jakubpa
 
 ## lessc usage
 
+First of all install less via
+
+```bash
+npm install -g less
+```
+
+then install the `less-plugin-clean-css`
+
 ```bash
 npm install -g less-plugin-clean-css
 ```

--- a/lib/clean-css-processor.js
+++ b/lib/clean-css-processor.js
@@ -43,7 +43,7 @@ module.exports = function() {
 
             if (sourceMap) {
                 if (sourcesContent) {
-                    for (var source = 0; source < sources.length; source++) {
+                    for (let source = 0; source < sources.length; source++) {
                         output.sourceMap.setSourceContent(sources[source], sourcesContent[source]);
                     }
                 }

--- a/lib/clean-css-processor.js
+++ b/lib/clean-css-processor.js
@@ -2,7 +2,7 @@
 
 const CleanCSS = require("clean-css");
 
-module.exports = function() {
+module.exports = function () {
     function CleanCSSProcessor(options) {
         this.options = options || {};
     }

--- a/lib/clean-css-processor.js
+++ b/lib/clean-css-processor.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var CleanCSS = require("clean-css");
+const CleanCSS = require("clean-css");
 
 module.exports = function() {
     function CleanCSSProcessor(options) {
@@ -9,7 +9,7 @@ module.exports = function() {
 
     CleanCSSProcessor.prototype = {
         process: function (css, extra) {
-            var options = this.options,
+            let options = this.options,
                 sourceMap = extra.sourceMap,
                 sources,
                 sourcesContent;
@@ -18,7 +18,7 @@ module.exports = function() {
                 options.sourceMap = sourceMap.getExternalSourceMap();
                 if (options.sourceMap) {
                     options.sourceMap = options.sourceMap.toString();
-                    var sourceMapObj = JSON.parse(options.sourceMap);
+                    const sourceMapObj = JSON.parse(options.sourceMap);
                     if (sourceMapObj.sourcesContent) {
                         sourcesContent = sourceMapObj.sourcesContent;
                         sources = sourceMapObj.sources;
@@ -39,7 +39,7 @@ module.exports = function() {
                 options.advanced = false;
             }
 
-            var output = new CleanCSS(options).minify(css);
+            const output = new CleanCSS(options).minify(css);
 
             if (sourceMap) {
                 if (sourcesContent) {
@@ -50,13 +50,13 @@ module.exports = function() {
                 sourceMap.setExternalSourceMap(JSON.stringify(output.sourceMap));
             }
 
-            var css = output.styles;
+            let outputCSS = output.styles;
             if (sourceMap) {
-                var sourceMapURL = sourceMap.getSourceMapURL();
-                css += sourceMap.getCSSAppendage();
+                const sourceMapURL = sourceMap.getSourceMapURL();
+                outputCSS += sourceMap.getCSSAppendage();
             }
 
-            return css;
+            return outputCSS;
         }
     };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,14 +9,14 @@ function LessPluginCleanCSS(options) {
 }
 
 LessPluginCleanCSS.prototype = {
-    install: function(less, pluginManager) {
+    install: function (less, pluginManager) {
         const CleanCSSProcessor = getCleanCSSProcessor(less);
         pluginManager.addPostProcessor(new CleanCSSProcessor(this.options));
     },
     printUsage: function () {
         usage.printUsage();
     },
-    setOptions: function(options) {
+    setOptions: function (options) {
         this.options = parseOptions(options);
     },
     minVersion: [2, 1, 0]

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var getCleanCSSProcessor = require("./clean-css-processor"),
+const getCleanCSSProcessor = require("./clean-css-processor"),
     usage = require("./usage"),
     parseOptions = require("./parse-options");
 
@@ -10,7 +10,7 @@ function LessPluginCleanCSS(options) {
 
 LessPluginCleanCSS.prototype = {
     install: function(less, pluginManager) {
-        var CleanCSSProcessor = getCleanCSSProcessor(less);
+        const CleanCSSProcessor = getCleanCSSProcessor(less);
         pluginManager.addPostProcessor(new CleanCSSProcessor(this.options));
     },
     printUsage: function () {

--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -2,11 +2,11 @@
 
 module.exports = function(options) {
     if (typeof options === "string") {
-        var cleanOptionArgs = options.split(" ");
+        const cleanOptionArgs = options.split(" ");
         options = {};
 
-        for (var i = 0; i < cleanOptionArgs.length; i++) {
-            var argSplit = cleanOptionArgs[i].split("="),
+        for (let i = 0; i < cleanOptionArgs.length; i++) {
+            const argSplit = cleanOptionArgs[i].split("="),
                 argName = argSplit[0].replace(/^-+/, "");
 
             switch (argName) {
@@ -21,7 +21,7 @@ module.exports = function(options) {
                     options.keepSpecialComments = 1;
                     break;
                 case "keepSpecialComments":
-                    var specialCommentOption = argSplit[1];
+                    let specialCommentOption = argSplit[1];
                     if (specialCommentOption !== "*") {
                         specialCommentOption = Number(specialCommentOption);
                     }

--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -1,6 +1,6 @@
 "use strict";
 
-module.exports = function(options) {
+module.exports = function (options) {
     if (typeof options === "string") {
         const cleanOptionArgs = options.split(" ");
         options = {};

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-    printUsage: function() {
+    printUsage: function () {
         console.log("");
         console.log("Clean CSS Plugin");
         console.log("specify plugin with --clean-css");
@@ -13,7 +13,7 @@ module.exports = {
         this.printOptions();
         console.log("");
     },
-    printOptions: function() {
+    printOptions: function () {
         console.log("we support the following arguments... 'keep-line-breaks', 'b'");
         console.log("'s0', 's1', 'advanced', 'rebase', 'keepSpecialComments', compatibility', 'rounding-precision'");
         console.log("'skip-aggressive-merging', 'skip-shorthand-compacting'");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,53 @@
+{
+  "name": "less-plugin-clean-css",
+  "version": "1.5.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "less-plugin-clean-css",
+      "version": "1.5.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clean-css": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/clean-css": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
+      "integrity": "sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==",
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 10.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "dependencies": {
+    "clean-css": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
+      "integrity": "sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==",
+      "requires": {
+        "source-map": "~0.6.0"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "less-plugin-clean-css",
   "version": "1.5.1",
   "description": "clean-css plugin for less.js",
-  "homepage": "http://lesscss.org",
+  "homepage": "https://lesscss.org",
   "author": "Luke Page",
   "contributors": [
     "The Core Less Team"
@@ -20,7 +20,7 @@
     "node": ">=0.10"
   },
   "dependencies": {
-    "clean-css": "^4.2.1"
+    "clean-css": "^5.3.2"
   },
   "keywords": [
     "less plugins",


### PR DESCRIPTION
* upgrade `clean-css` to `5.3.2`
* use `const` and `let` instead of `var`
* add .editorconfig
* improve readme

It should still work, but please check again

```bash
❯ lessc file.less --clean-css="--s1 --advanced --compatibility=ie8"
h2{color:coral}h3{color:purple}% 

```